### PR TITLE
Update setup.py With Long Desc Content Type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
     license='Apache-2.0',
     description='Wavefront Pyformance Library',
     long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
     keywords=[
         'PyFormance',
         'Wavefront',


### PR DESCRIPTION
Will make the following twine check to pass
```
twine check dist/*
Checking distribution dist/wavefront_pyformance-0.9.3-py3-none-any.whl: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Failed
The project's long_description has invalid markup which will not be rendered on PyPI. The following syntax errors were detected:
line 27: Warning: Inline literal start-string without end-string.
Checking distribution dist/wavefront-pyformance-0.9.3.tar.gz: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Failed
```