### PR TITLE
Add build version report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: bionic
 language: python
 python:
-  - '2.7'
   - '3.5'
   - '3.6'
   - '3.7'

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 This is a plugin for [pyformance](https://github.com/omergertel/pyformance) which adds Wavefront reporters (via proxy or direct ingestion) and an abstraction that supports tagging at the host level. It also includes support for Wavefront delta counters.
 
 ## Requirements
-Python 2.7+ and Python 3.x are supported.
+Python 3.x are supported.
 
 ```
 pip install wavefront-pyformance

--- a/example.py
+++ b/example.py
@@ -15,7 +15,7 @@ def report_metrics(host, server, token):
     reg = tagged_registry.TaggedRegistry()
 
     wf_proxy_reporter = wavefront_reporter.WavefrontProxyReporter(
-        host=host, port=2878, registry=reg,
+        host=host, port=2878, distribution_port=2878, registry=reg,
         source='wavefront-pyformance-example',
         tags={'key1': 'val1', 'key2': 'val2'},
         prefix='python.proxy.').report_minute_distribution()

--- a/example_runtime_metrics.py
+++ b/example_runtime_metrics.py
@@ -15,7 +15,7 @@ def report_metrics(host, server='', token=''):
     reg = tagged_registry.TaggedRegistry()
 
     wf_proxy_reporter = wavefront_reporter.WavefrontProxyReporter(
-        host=host, port=2878, registry=reg,
+        host=host, port=2878, distribution_port=2878, registry=reg,
         source='runtime-metric-test',
         tags={'global_tag1': 'val1', 'global_tag2': 'val2'},
         prefix='python.proxy.',

--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -1,6 +1,6 @@
 open_source_license.txt
 
-Wavefront by VMware PyFormance SDK for Python 1.1.0 GA
+Wavefront by VMware PyFormance SDK for Python 1.2.0 GA
 
 ======================================================================
 
@@ -256,4 +256,4 @@ Source Files is valid for three years from the date you acquired or last used th
 Software product. Alternatively, the Source Files may accompany the
 VMware service.
 
-[WAVEFRONTPYFORMANCESDKPYTHON110GAAB020720]
+[WAVEFRONTPYFORMANCESDKPYTHON120GAAB020720]

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-pyformance',
-    version='1.1.0',
+    version='1.2.0',
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-pyformance',
@@ -46,7 +46,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=('tests',)),
     install_requires=(
         'pyformance>=0.4',
-        'wavefront-sdk-python>=1.1',
+        'wavefront-sdk-python>=1.7.4',
         'psutil>=5.6.3'
         )
 )

--- a/wavefront_pyformance/tagged_registry.py
+++ b/wavefront_pyformance/tagged_registry.py
@@ -31,28 +31,28 @@ class TaggedRegistry(pyformance.MetricsRegistry):
     # pylint: disable=arguments-differ
     def counter(self, key, tags=None):
         """Get a counter based on a encoded key."""
-        return super(TaggedRegistry, self).counter(self.encode_key(key, tags))
+        return super().counter(self.encode_key(key, tags))
 
     # pylint: disable=arguments-differ
     def histogram(self, key, tags=None):
         """Get a histogram based on a encoded key."""
-        return super(TaggedRegistry, self).histogram(
+        return super().histogram(
             self.encode_key(key, tags))
 
     # pylint: disable=arguments-differ
     def gauge(self, key, gauge=None, default=float('nan'), tags=None):
         """Get a gauge based on a encoded key."""
-        return super(TaggedRegistry, self).gauge(
+        return super().gauge(
             self.encode_key(key, tags), gauge, default)
 
     # pylint: disable=arguments-differ
     def meter(self, key, tags=None):
         """Get a meter based on a encoded key."""
-        return super(TaggedRegistry, self).meter(self.encode_key(key, tags))
+        return super().meter(self.encode_key(key, tags))
 
     def timer(self, key, tags=None):
         """Get a timer based on a encoded key."""
-        return super(TaggedRegistry, self).timer(self.encode_key(key, tags))
+        return super().timer(self.encode_key(key, tags))
 
     def has_counter(self, key, tags=None):
         """Return True if given key matches any counters."""

--- a/wavefront_pyformance/wavefront_histogram.py
+++ b/wavefront_pyformance/wavefront_histogram.py
@@ -63,7 +63,7 @@ class WavefrontHistogram(pyformance.meters.Histogram):
         @param clock_millis: A function which returns timestamp.
         @type clock_millis: function
         """
-        super(WavefrontHistogram, self).__init__()
+        super().__init__()
         self._delegate = histogram_impl.WavefrontHistogramImpl(clock_millis)
 
     def add(self, value):

--- a/wavefront_pyformance/wavefront_reporter.py
+++ b/wavefront_pyformance/wavefront_reporter.py
@@ -7,6 +7,8 @@ import json
 import pyformance.reporters.reporter
 
 import wavefront_sdk
+from wavefront_sdk.common.constants import SDK_METRIC_PREFIX
+from wavefront_sdk.common.metrics.registry import WavefrontSdkMetricsRegistry
 from wavefront_sdk.common.utils import get_sem_ver
 from wavefront_sdk.entities.histogram import histogram_granularity
 
@@ -37,6 +39,7 @@ class WavefrontReporter(pyformance.reporters.reporter.Reporter):
         self.tags = tags or {}
         self.histogram_granularities = set()
         self.enable_runtime_metrics = enable_runtime_metrics
+        self._sdk_metrics_registry = None
 
     @staticmethod
     def decode_key(key):
@@ -62,8 +65,6 @@ class WavefrontReporter(pyformance.reporters.reporter.Reporter):
         :return: None
         """
         registry = registry or self.registry
-        registry.gauge('version', tags=self.tags).set_value(
-            get_sem_ver('wavefront-pyformance'))
         if self.enable_runtime_metrics:
             col = runtime_metrics.RuntimeCollector(registry)
             col.collect()
@@ -112,6 +113,8 @@ class WavefrontReporter(pyformance.reporters.reporter.Reporter):
     def stop(self):
         """Stop pyformance and wavefront reporter."""
         self._report(registry=self.registry, flush_current_hist=True)
+        if self._sdk_metrics_registry:
+            self._sdk_metrics_registry.close(timeout_secs=1)
         super().stop()
         self.wavefront_client.close()
 
@@ -138,7 +141,8 @@ class WavefrontProxyReporter(WavefrontReporter):
     def __init__(self, host, port=2878, distribution_port=None,
                  source='wavefront-pyformance', registry=None,
                  reporting_interval=60, clock=None, prefix='proxy.',
-                 tags=None, enable_runtime_metrics=False):
+                 tags=None, enable_runtime_metrics=False,
+                 enable_internal_metrics=True):
         """Run parent __init__ and do proxy reporter specific setup."""
         super().__init__(
             source=source, registry=registry,
@@ -147,6 +151,13 @@ class WavefrontProxyReporter(WavefrontReporter):
         self.wavefront_client = wavefront_sdk.WavefrontProxyClient(
             host=host, metrics_port=port, distribution_port=distribution_port,
             tracing_port=None)
+        if enable_internal_metrics:
+            self._sdk_metrics_registry = WavefrontSdkMetricsRegistry(
+                wf_metric_sender=self.wavefront_client,
+                source=source, tags=tags,
+                prefix='{}.pyformance.sender.proxy'.format(SDK_METRIC_PREFIX))
+            self._sdk_metrics_registry.new_gauge(
+                'version', lambda: get_sem_ver('wavefront-pyformance'))
 
     def report_now(self, registry=None, timestamp=None):
         """Collect metrics from registry and report them to Wavefront."""
@@ -164,7 +175,8 @@ class WavefrontDirectReporter(WavefrontReporter):
     # pylint: disable=too-many-arguments
     def __init__(self, server, token, source='wavefront-pyformance',
                  registry=None, reporting_interval=60, clock=None,
-                 prefix='direct.', tags=None, enable_runtime_metrics=False):
+                 prefix='direct.', tags=None, enable_runtime_metrics=False,
+                 enable_internal_metrics=True):
         """Run parent __init__ and do direct reporter specific setup."""
         super().__init__(
             source=source, registry=registry,
@@ -176,6 +188,13 @@ class WavefrontDirectReporter(WavefrontReporter):
         self.wavefront_client = wavefront_sdk.WavefrontDirectClient(
             self.server, token, batch_size=self.batch_size,
             flush_interval_seconds=reporting_interval)
+        if enable_internal_metrics:
+            self._sdk_metrics_registry = WavefrontSdkMetricsRegistry(
+                wf_metric_sender=self.wavefront_client,
+                source=source, tags=tags,
+                prefix='{}.pyformance.sender.direct'.format(SDK_METRIC_PREFIX))
+            self._sdk_metrics_registry.new_gauge(
+                'version', lambda: get_sem_ver('wavefront-pyformance'))
 
     @staticmethod
     def _validate_url(server):  # pylint: disable=no-self-use

--- a/wavefront_pyformance/wavefront_reporter.py
+++ b/wavefront_pyformance/wavefront_reporter.py
@@ -7,6 +7,7 @@ import json
 import pyformance.reporters.reporter
 
 import wavefront_sdk
+from wavefront_sdk.common.utils import get_sem_ver
 from wavefront_sdk.entities.histogram import histogram_granularity
 
 from . import delta
@@ -27,7 +28,7 @@ class WavefrontReporter(pyformance.reporters.reporter.Reporter):
                  reporting_interval=60, clock=None, prefix='', tags=None,
                  enable_runtime_metrics=False):
         """Construct Wavefront Reporter."""
-        super(WavefrontReporter, self).__init__(
+        super().__init__(
             registry=registry, reporting_interval=reporting_interval,
             clock=clock)
         self.wavefront_client = None
@@ -61,6 +62,8 @@ class WavefrontReporter(pyformance.reporters.reporter.Reporter):
         :return: None
         """
         registry = registry or self.registry
+        registry.gauge('version', tags=self.tags).set_value(
+            get_sem_ver('wavefront-pyformance'))
         if self.enable_runtime_metrics:
             col = runtime_metrics.RuntimeCollector(registry)
             col.collect()
@@ -109,7 +112,7 @@ class WavefrontReporter(pyformance.reporters.reporter.Reporter):
     def stop(self):
         """Stop pyformance and wavefront reporter."""
         self._report(registry=self.registry, flush_current_hist=True)
-        super(WavefrontReporter, self).stop()
+        super().stop()
         self.wavefront_client.close()
 
     def report_minute_distribution(self):
@@ -137,7 +140,7 @@ class WavefrontProxyReporter(WavefrontReporter):
                  reporting_interval=60, clock=None, prefix='proxy.',
                  tags=None, enable_runtime_metrics=False):
         """Run parent __init__ and do proxy reporter specific setup."""
-        super(WavefrontProxyReporter, self).__init__(
+        super().__init__(
             source=source, registry=registry,
             reporting_interval=reporting_interval, clock=clock, prefix=prefix,
             tags=tags, enable_runtime_metrics=enable_runtime_metrics)
@@ -148,7 +151,7 @@ class WavefrontProxyReporter(WavefrontReporter):
     def report_now(self, registry=None, timestamp=None):
         """Collect metrics from registry and report them to Wavefront."""
         timestamp = timestamp or int(round(self.clock.time()))
-        super(WavefrontProxyReporter, self).report_now(registry, timestamp)
+        super().report_now(registry, timestamp)
 
 
 class WavefrontDirectReporter(WavefrontReporter):
@@ -163,7 +166,7 @@ class WavefrontDirectReporter(WavefrontReporter):
                  registry=None, reporting_interval=60, clock=None,
                  prefix='direct.', tags=None, enable_runtime_metrics=False):
         """Run parent __init__ and do direct reporter specific setup."""
-        super(WavefrontDirectReporter, self).__init__(
+        super().__init__(
             source=source, registry=registry,
             reporting_interval=reporting_interval, clock=clock, prefix=prefix,
             tags=tags, enable_runtime_metrics=enable_runtime_metrics)
@@ -184,5 +187,5 @@ class WavefrontDirectReporter(WavefrontReporter):
 
     def report_now(self, registry=None, timestamp=None):
         """Collect metrics from registry and report them to Wavefront."""
-        super(WavefrontDirectReporter, self).report_now(registry, timestamp)
+        super().report_now(registry, timestamp)
         self.wavefront_client.flush_now()


### PR DESCRIPTION
* Remove python 2.7 support since the dependency core sdk does not support 2.7 since https://github.com/wavefrontHQ/wavefront-sdk-python/pull/70
* Report the version number as "~sdk.python.pyformance.sender.direct.version" and "~sdk.python.pyformance.sender.proxy.version"