### PR TITLE
Update wavefront-sdk-python version to 1.8.0

### DIFF
--- a/example.py
+++ b/example.py
@@ -10,20 +10,8 @@ from wavefront_pyformance import wavefront_histogram
 from wavefront_pyformance import wavefront_reporter
 
 
-def report_metrics(host, server, token):
+def report_metrics(proxy_reporter, direct_reporter):
     """Metrics Reporting Function Example."""
-    reg = tagged_registry.TaggedRegistry()
-
-    wf_proxy_reporter = wavefront_reporter.WavefrontProxyReporter(
-        host=host, port=2878, distribution_port=2878, registry=reg,
-        source='wavefront-pyformance-example',
-        tags={'key1': 'val1', 'key2': 'val2'},
-        prefix='python.proxy.').report_minute_distribution()
-    wf_direct_reporter = wavefront_reporter.WavefrontDirectReporter(
-        server=server, token=token, registry=reg,
-        source='wavefront-pyformance-exmaple',
-        tags={'key1': 'val1', 'key2': 'val2'},
-        prefix='python.direct.').report_minute_distribution()
 
     # counter
     c_1 = reg.counter('foo_count', tags={'counter_key': 'counter_val'})
@@ -59,10 +47,10 @@ def report_metrics(host, server, token):
     h_2.add(1.0)
     h_2.add(2.0)
 
-    wf_direct_reporter.report_now()
-    wf_direct_reporter.stop()
-    wf_proxy_reporter.report_now()
-    wf_proxy_reporter.stop()
+    direct_reporter.report_now()
+    direct_reporter.stop()
+    proxy_reporter.report_now()
+    proxy_reporter.stop()
 
 
 if __name__ == '__main__':
@@ -72,6 +60,21 @@ if __name__ == '__main__':
     _.add_argument('server', help='Wavefront server for direct ingestion.')
     _.add_argument('token', help='Wavefront API token.')
     ARGS = _.parse_args()
+
+    reg = tagged_registry.TaggedRegistry()
+
+    wf_proxy_reporter = wavefront_reporter.WavefrontProxyReporter(
+        host=ARGS.host, port=2878, distribution_port=2878, registry=reg,
+        source='wavefront-pyformance-example',
+        tags={'key1': 'val1', 'key2': 'val2'},
+        prefix='python.proxy.').report_minute_distribution()
+
+    wf_direct_reporter = wavefront_reporter.WavefrontDirectReporter(
+        server=ARGS.server, token=ARGS.token, registry=reg,
+        source='wavefront-pyformance-exmaple',
+        tags={'key1': 'val1', 'key2': 'val2'},
+        prefix='python.direct.').report_minute_distribution()
+
     while True:
-        report_metrics(ARGS.host, ARGS.server, ARGS.token)
+        report_metrics(wf_proxy_reporter, wf_direct_reporter)
         time.sleep(1)

--- a/example.py
+++ b/example.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     reg = tagged_registry.TaggedRegistry()
 
     wf_proxy_reporter = wavefront_reporter.WavefrontProxyReporter(
-        host=ARGS.host, port=2878, distribution_port=2878, registry=reg,
+        host=ARGS.host, port=2878, registry=reg,
         source='wavefront-pyformance-example',
         tags={'key1': 'val1', 'key2': 'val2'},
         prefix='python.proxy.').report_minute_distribution()

--- a/example.py
+++ b/example.py
@@ -12,7 +12,6 @@ from wavefront_pyformance import wavefront_reporter
 
 def report_metrics(proxy_reporter, direct_reporter):
     """Metrics Reporting Function Example."""
-
     # counter
     c_1 = reg.counter('foo_count', tags={'counter_key': 'counter_val'})
     c_1.inc()

--- a/example_runtime_metrics.py
+++ b/example_runtime_metrics.py
@@ -15,7 +15,7 @@ def report_metrics(host, server='', token=''):
     reg = tagged_registry.TaggedRegistry()
 
     wf_proxy_reporter = wavefront_reporter.WavefrontProxyReporter(
-        host=host, port=2878, distribution_port=2878, registry=reg,
+        host=host, port=2878, registry=reg,
         source='runtime-metric-test',
         tags={'global_tag1': 'val1', 'global_tag2': 'val2'},
         prefix='python.proxy.',

--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -1,6 +1,6 @@
 open_source_license.txt
 
-Wavefront by VMware PyFormance SDK for Python 1.2.0 GA
+Wavefront by VMware PyFormance SDK for Python 1.3.0 GA
 
 ======================================================================
 
@@ -256,4 +256,4 @@ Source Files is valid for three years from the date you acquired or last used th
 Software product. Alternatively, the Source Files may accompany the
 VMware service.
 
-[WAVEFRONTPYFORMANCESDKPYTHON120GAAB020720]
+[WAVEFRONTPYFORMANCESDKPYTHON130GAAB020720]

--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -1,6 +1,6 @@
 open_source_license.txt
 
-Wavefront by VMware PyFormance SDK for Python 1.3.0 GA
+Wavefront by VMware PyFormance SDK for Python 1.2.1 GA
 
 ======================================================================
 
@@ -256,4 +256,4 @@ Source Files is valid for three years from the date you acquired or last used th
 Software product. Alternatively, the Source Files may accompany the
 VMware service.
 
-[WAVEFRONTPYFORMANCESDKPYTHON130GAAB020720]
+[WAVEFRONTPYFORMANCESDKPYTHON121GAAB020720]

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=('tests',)),
     install_requires=(
         'pyformance>=0.4',
-        'wavefront-sdk-python>=1.7.4',
+        'wavefront-sdk-python>=1.7.9',
         'psutil>=5.6.3'
         )
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-pyformance',
-    version='1.3.0',
+    version='1.2.1',
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-pyformance',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-pyformance',
-    version='1.2.0',
+    version='1.3.0',
     author='Wavefront by VMware',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-pyformance',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=('tests',)),
     install_requires=(
         'pyformance>=0.4',
-        'wavefront-sdk-python>=1.7.9',
+        'wavefront-sdk-python>=1.8.0',
         'psutil>=5.6.3'
         )
 )

--- a/wavefront_pyformance/wavefront_reporter.py
+++ b/wavefront_pyformance/wavefront_reporter.py
@@ -138,7 +138,7 @@ class WavefrontProxyReporter(WavefrontReporter):
     """Requires a host and port to report data to a Wavefront proxy."""
 
     # pylint: disable=too-many-arguments
-    def __init__(self, host, port=2878, distribution_port=None,
+    def __init__(self, host, port=2878,
                  source='wavefront-pyformance', registry=None,
                  reporting_interval=60, clock=None, prefix='proxy.',
                  tags=None, enable_runtime_metrics=False,

--- a/wavefront_pyformance/wavefront_reporter.py
+++ b/wavefront_pyformance/wavefront_reporter.py
@@ -6,12 +6,11 @@ import json
 
 import pyformance.reporters.reporter
 
-import wavefront_sdk
 from wavefront_sdk.common.constants import SDK_METRIC_PREFIX
 from wavefront_sdk.common.metrics.registry import WavefrontSdkMetricsRegistry
 from wavefront_sdk.common.utils import get_sem_ver
-from wavefront_sdk.entities.histogram import histogram_granularity
 from wavefront_sdk.client_factory import WavefrontClientFactory
+from wavefront_sdk.entities.histogram import histogram_granularity
 
 from . import delta
 from . import runtime_metrics

--- a/wavefront_pyformance/wavefront_reporter.py
+++ b/wavefront_pyformance/wavefront_reporter.py
@@ -190,8 +190,9 @@ class WavefrontDirectReporter(WavefrontReporter):
         self.batch_size = 10000
 
         client_factory = WavefrontClientFactory()
+        parse_url = urlparse(server)
         client_factory.add_client(
-            url="https://{}@{}".format(token, urlparse(server).hostname),
+            url = "{}://{}@{}".format(parse_url[0], token, parse_url[1]),
             batch_size=self.batch_size,
             flush_interval_seconds=reporting_interval)
         self.wavefront_client = client_factory.get_client()

--- a/wavefront_pyformance/wavefront_reporter.py
+++ b/wavefront_pyformance/wavefront_reporter.py
@@ -6,10 +6,10 @@ import json
 
 import pyformance.reporters.reporter
 
+from wavefront_sdk.client_factory import WavefrontClientFactory
 from wavefront_sdk.common.constants import SDK_METRIC_PREFIX
 from wavefront_sdk.common.metrics.registry import WavefrontSdkMetricsRegistry
 from wavefront_sdk.common.utils import get_sem_ver
-from wavefront_sdk.client_factory import WavefrontClientFactory
 from wavefront_sdk.entities.histogram import histogram_granularity
 
 from . import delta
@@ -191,7 +191,7 @@ class WavefrontDirectReporter(WavefrontReporter):
         client_factory = WavefrontClientFactory()
         parse_url = urlparse(server)
         client_factory.add_client(
-            url = "{}://{}@{}".format(parse_url[0], token, parse_url[1]),
+            url="{}://{}@{}".format(parse_url[0], token, parse_url[1]),
             batch_size=self.batch_size,
             flush_interval_seconds=reporting_interval)
         self.wavefront_client = client_factory.get_client()


### PR DESCRIPTION
`wavefront-sdk-python` v1.7.9 Sends internal diagnostic metrics as delta counters.