### PR TITLE
Don't crash when collecting runtime metrics on platforms that don't expose ctx switches

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 setuptools.setup(
     name='wavefront-pyformance',
-    version='1.2.3',  # Please increment with every Pull Request.
+    version='1.2.4',  # Please increment with every Pull Request.
     author='VMware Aria Operations for Applications Team',
     author_email='chitimba@wavefront.com',
     url='https://github.com/wavefrontHQ/wavefront-pyformance',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setuptools.setup(
         'Intended Audience :: Information Technology',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/wavefront_pyformance/__init__.py
+++ b/wavefront_pyformance/__init__.py
@@ -1,2 +1,13 @@
 """Wavefront PyFormance Plugin."""
-__version__ = '1.2.3'
+
+__version__ = None
+
+try:
+    import importlib.metadata
+    try:
+        __version__ = importlib.metadata.version('wavefront-pyformance')
+    except importlib.metadata.PackageNotFoundError:
+        # __version__ is only available when distribution is installed.
+        pass
+except ImportError:
+    pass

--- a/wavefront_pyformance/runtime_metrics.py
+++ b/wavefront_pyformance/runtime_metrics.py
@@ -115,7 +115,12 @@ class RuntimeCollector(object):
 
     def collect_contextswitches(self):
         """Collect Context Switches."""
-        ctx_switches = self.process.num_ctx_switches()
+        try:
+            ctx_switches = self.process.num_ctx_switches()
+        except NotImplementedError:
+            # some platforms do not expose ctx switches information, this is ok
+            ctx_switches = None
+
         if ctx_switches:
             voluntary = ctx_switches.voluntary
             involuntary = ctx_switches.involuntary


### PR DESCRIPTION
`num_ctx_switches` in psutil may raise `NotImplementedError` when it can't find ctx switches information in the process status file `/proc/$pid/status`:

```
    def num_ctx_switches(self,
                         _ctxsw_re=re.compile(br'ctxt_switches:\t(\d+)')):
        data = self._read_status_file()
        ctxsw = _ctxsw_re.findall(data)
        if not ctxsw:
            raise NotImplementedError(
                "'voluntary_ctxt_switches' and 'nonvoluntary_ctxt_switches'"
                "lines were not found in %s/%s/status; the kernel is "
                "probably older than 2.6.23" % (
                    self._procfs_path, self.pid))
        else:
            return _common.pctxsw(int(ctxsw[0]), int(ctxsw[1]))
```

The comment in the library says that this may happen on kernels older than 2.6.23, but it also happens when the process is running in Google Cloud Run.

When this happens, it should be safe to ignore and simply not collect any ctx switches metrics.